### PR TITLE
Revise to use CROSS APPLY

### DIFF
--- a/SQL Views/OldestAndNewest.md
+++ b/SQL Views/OldestAndNewest.md
@@ -5,42 +5,42 @@ Get the oldest and most recent record for each group.
 ## View Definition
 
 ```
-select 
-people.people_id,
-earliest.event_definition_id as earliest_event_definition_id,
-earliest.event_log_id as earliest_event_log_id,
-earliest.date_entered as earliest_date_entered,
-latest.event_definition_id as latest_event_definition_id,
-latest.event_log_id as latest_event_log_id,
-latest.date_entered as latest_date_entered
-from people
-cross apply (
-  select 
-  people_id,
-  event_definition_id,
-  event_log_id,
-  date_entered
-  from event_log
-  where event_log.people_id = people.people_id
-  order by date_entered asc offset 0 rows fetch next 1 row only
-) as earliest
-cross apply (
-  select 
-  event_definition_id,
-  event_log_id,
-  date_entered
-  from event_log
-  where event_log.people_id = earliest.people_id
-  and event_log.event_definition_id = earliest.event_definition_id -- optionally limit to same event_definition_id
-  order by date_entered desc offset 0 rows fetch next 1 row only
-) as latest
+SELECT 
+  people.people_id,
+  earliest.event_definition_id AS earliest_event_definition_id,
+  earliest.event_log_id AS earliest_event_log_id,
+  earliest.date_entered AS earliest_date_entered,
+  latest.event_definition_id AS latest_event_definition_id,
+  latest.event_log_id AS latest_event_log_id,
+  latest.date_entered AS latest_date_entered
+FROM people
+CROSS APPLY (
+  SELECT
+    people_id,
+    event_definition_id,
+    event_log_id,
+    date_entered
+  FROM event_log
+  WHERE event_log.people_id = people.people_id
+  ORDER BY date_entered ASC OFFSET 0 ROWS FETCH NEXT 1 ROW ONLY
+) AS earliest
+CROSS APPLY (
+  SELECT
+    event_definition_id,
+    event_log_id,
+    date_entered
+  FROM event_log
+  WHERE event_log.people_id = earliest.people_id
+  AND event_log.event_definition_id = earliest.event_definition_id -- optionally limit to same event_definition_id
+  ORDER BY date_entered DESC OFFSET 0 ROWS FETCH NEXT 1 ROW ONLY
+) AS latest
 -- Optional ORDER BY clause
-ORDER BY sub.date_entered
+ORDER BY earliest.date_entered -- or latest.date_entered
 ```
 
 ## Other Details
 
-The "sub" alias below could be joined to any table that event_log could be joined to.
+The "earliest" and "latest" aliases above could be joined to any table that event_log could be joined to.
 
 In this case:
     - groups are represented by people_id and


### PR DESCRIPTION
Proposed more efficient query using cross apply and offset-fetch to find earliest and latest events. Also added constraint to look for the same event_definition_id (first and last occasion of each event per person). Approximately 50x faster to run