### PR TITLE
Clear actual_date on scheduled tasks

### DIFF
--- a/JavaScript Functions/Clear actual_date on scheduled tasks
+++ b/JavaScript Functions/Clear actual_date on scheduled tasks
@@ -1,0 +1,3 @@
+if (formMode == "ADD"){
+     setFormElement('actual_date', null)
+}


### PR DESCRIPTION
To clear the scheduled date in the actual_date column when opening a scheduled task.